### PR TITLE
Fix repo header template

### DIFF
--- a/gitea/gitea/templates/repo/header.tmpl
+++ b/gitea/gitea/templates/repo/header.tmpl
@@ -111,7 +111,7 @@
 
 				{{if and (.Permission.CanRead $.UnitTypeReleases) (not .IsEmptyRepo) }}
 				<a class="item {{if .PageIsReleaseList}}acty{{end}}" href="{{.RepoLink}}/releases">
-					{{svg "octicon-tag" 16}} {{.i18n.Tr "repo.releases"}} <span class="ui {{if not .Repository.NumReleases}}gray{{else}}blue{{end}} small label">{{.Repository.NumReleases}}</span>
+					{{svg "octicon-tag" 16}} {{.i18n.Tr "repo.releases"}} <span class="ui {{if not .NumReleases}}gray{{else}}blue{{end}} small label">{{.NumReleases}}</span>
 				</a>
 				{{end}}
 


### PR DESCRIPTION
Per https://github.com/go-gitea/gitea/pull/10968 

Specifically [this diff](https://github.com/go-gitea/gitea/pull/10968/files#diff-10ae9839f863d91485fcbc6168061b00R120)